### PR TITLE
feat: Change thread creation functionality

### DIFF
--- a/src/components/ChatList/ChatHistoryDrawer.tsx
+++ b/src/components/ChatList/ChatHistoryDrawer.tsx
@@ -16,7 +16,7 @@ import ListItemText from "@mui/material/ListItemText";
 import Toolbar from "@mui/material/Toolbar";
 import * as React from "react";
 import { useAuthContext } from "../../context/AuthContext";
-import { Thread, useThreadContext } from "../../context/ThreadContext";
+import { useThreadContext } from "../../context/ThreadContext";
 import ChatWindow from "../ChatWindow/ChatWindow";
 
 const drawerWidth = 300;
@@ -32,10 +32,8 @@ interface Props {
 
 export default function ChatHistoryDrawer(props: Props) {
   const { logout } = useAuthContext();
-  const { threads, listThreads, createThread } = useThreadContext();
-  const [selectedThread, setSelectedThread] = React.useState<Thread>(
-    threads[0],
-  );
+  const { threads, listThreads, createThread, setSelectedThread } =
+    useThreadContext();
   // const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(
   //   null,
   // );
@@ -63,12 +61,7 @@ export default function ChatHistoryDrawer(props: Props) {
           <Fab
             variant="extended"
             color="primary"
-            onClick={() =>
-              createThread({
-                title: "New Chat",
-                message: "Hello, how can I help you?",
-              })
-            }
+            onClick={() => createThread()}
           >
             <AddIcon sx={{ mr: 1 }} />
             New Chat
@@ -78,7 +71,7 @@ export default function ChatHistoryDrawer(props: Props) {
         <List>
           {threads.map((thread, index) => (
             <ListItem key={thread.id} disablePadding>
-              <ListItemButton onClick={() => setSelectedThread(thread)}>
+              <ListItemButton onClick={() => setSelectedThread(thread.id)}>
                 {/*<ListItemIcon>
                                     {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
                                 </ListItemIcon>*/}
@@ -175,7 +168,7 @@ export default function ChatHistoryDrawer(props: Props) {
           {drawer}
         </Drawer>
       </Box>
-      <ChatWindow thread={selectedThread} />
+      <ChatWindow />
     </Box>
   );
 }

--- a/src/components/ChatWindow/ChatWindow.tsx
+++ b/src/components/ChatWindow/ChatWindow.tsx
@@ -18,12 +18,13 @@ interface MainContentProps {
 }
 
 // MainContent component
-const MainContent: React.FC<MainContentProps> = ({ thread }) => {
-  const { postMessage, threads } = useThreadContext();
+const MainContent: React.FC<MainContentProps> = () => {
+  const { postMessage, threads, selectedThreadId } = useThreadContext();
   // State for the chat message and text field rows
   const [message, setMessage] = useState("");
   const [rows, setRows] = useState(3);
-  const messages = threads.find((t) => t.id === thread?.id)?.messages;
+  const selectedThread = threads.find((t) => t.id === selectedThreadId);
+  const messages = selectedThread?.messages;
 
   // Ref for scrolling to the bottom of the chat
   const chatEndRef = useRef<HTMLDivElement>(null);
@@ -41,8 +42,8 @@ const MainContent: React.FC<MainContentProps> = ({ thread }) => {
 
   // Function to handle sending a message
   const handleSendMessage = () => {
-    if (message && thread) {
-      postMessage(thread.id, message);
+    if (message && selectedThread) {
+      postMessage(selectedThread.id, message, selectedThread.newThread);
       setMessage("");
     }
   };
@@ -62,7 +63,7 @@ const MainContent: React.FC<MainContentProps> = ({ thread }) => {
       <br />
       <br />
       <PluginSelector></PluginSelector>
-      <Typography paragraph>{thread?.title}</Typography>
+      <Typography paragraph>{selectedThread?.title}</Typography>
       <Box sx={{ flexGrow: 1, overflowY: "auto" }}>
         <List>
           {messages?.map((msg) => (


### PR DESCRIPTION
- Only post a new thread when the first message is sent. 
- Make the default title of a thread "New Chat".
- Once the first message is sent, rename the title to a truncated version of the first message. 
- Handle thread selection in the thread context to simplify reselection.

Still TODO:

- Have the 'welcome message' defined in the backend so it can be properly retained in the database. (or should this be sent when creating the thread?)

![image](https://github.com/DevoteamNL/infini-connect-ui/assets/5176836/21856cb2-42c8-4077-9ed1-91b18daecd24)
![image](https://github.com/DevoteamNL/infini-connect-ui/assets/5176836/605c3fcc-bd77-4b77-baa3-ecbce3ea0056)
